### PR TITLE
Peak spikes at 0:00

### DIFF
--- a/vnstat
+++ b/vnstat
@@ -66,7 +66,7 @@ sub printData {
 sub normalize {
 	my ($value,$unit) = @_;
 	my $multiplier = 1;
-	my @units = ('Kib','MiB','GiB','TiB');
+	my @units = ('KiB','MiB','GiB','TiB');
 
 	for ( my $i = 0; $i < @units; $i++ ) {
 		$multiplier *= 1024;


### PR DESCRIPTION
A typo on the normalize subroutine causes peak spikes at 0:00 each day. The data read from the vnstat command that is in the KiB range its been gathered in PiB instead of KiB because of the typo. The typo is on line 69 where is read as Kib instead of KiB.
